### PR TITLE
Add support of GCM encryption mode

### DIFF
--- a/src/main/groovy/grails/plugin/cookiesession/CookieSessionRepository.groovy
+++ b/src/main/groovy/grails/plugin/cookiesession/CookieSessionRepository.groovy
@@ -419,11 +419,12 @@ class CookieSessionRepository implements SessionRepository, InitializingBean, Ap
         if( useInitializationVector ){
           int ivLen = input[0]
           if ( useGCMmode ) {
-            GCMParameterSpec ivSpec = new GCMParameterSpec(128, input[ 1 + ivLen..-1])
+            GCMParameterSpec ivSpec = new GCMParameterSpec(128, input, 1, ivLen)
+            cipher.init( Cipher.DECRYPT_MODE, cryptoKey, ivSpec )
           } else {
             IvParameterSpec ivSpec = new IvParameterSpec(input, 1, ivLen)
+            cipher.init( Cipher.DECRYPT_MODE, cryptoKey, ivSpec )
           }
-          cipher.init( Cipher.DECRYPT_MODE, cryptoKey, ivSpec )
           input = cipher.doFinal( input, 1 + ivLen, input.length - 1 - ivLen )
         } else {
           cipher.init( Cipher.DECRYPT_MODE, cryptoKey )


### PR DESCRIPTION
AES/GCM/NoPadding requires to use GCMParameterSpec class instead of IvParameterSpec.